### PR TITLE
Add android env profile setup

### DIFF
--- a/setup_android_env.sh
+++ b/setup_android_env.sh
@@ -1,5 +1,5 @@
 echo 'export ANDROID_HOME="/Users/[USER_NAME]/Library/Android/sdk"' >> ~/.bash_profile
 
-export PATH=${PATH}:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools >> ~/.bash_profile
+echo 'export PATH=${PATH}:${ANDROID_HOME}/emulator:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/tools' >> ~/.bash_profile
 
 . ~/.bash_profile


### PR DESCRIPTION
- Need this to run `adb` or  start an emulator with `emulator -avd` in command line 
- This is used for Slave machine which is intended to run the build step/test/emulator.