### PR TITLE
Start jenkins-blueocean container when startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@
 ## HOW-TO run jenkins in docker and attach the volume:
 - Install Docker.
 - Run `$ sh docker_run.sh`.
-- Jenkins is up at `https://localhost:8085` without any security. Next step is to re-configure the security and re-new the credentials to access to project's repository.
+- Jenkins is up at `http://localhost` without any security. Next step is to re-configure the security and re-new the credentials to access to project's repository.
 
 # Re-config the Jenkins base security:
 - Go to "Manage Jenkins" -> "Configure Global Security" -> "Enable Security" -> "Use Jenkin's own database" -> "Allow users to sign up".
 - Under Authorization, select: "Matrix-based security" and add new `admin` user with full permission.
-- Restart jenkins by log to `https://localhost:8085/restart`.
+- Restart jenkins by log to `http://localhost/restart`.
 - Signup with `admin` username. From now you can decide to disable `Allow users to sign up`.

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,1 +1,1 @@
-docker run -d -v $("pwd")/volume-blueocean:/var/jenkins_home -p 80:8080 -p 50000:50000 --name=jenkins-blueocean -i jenkinsci/blueocean:1.3.3
+docker run --restart=always -d -v $("pwd")/volume-blueocean:/var/jenkins_home -p 80:8080 -p 50000:50000 --name=jenkins-blueocean -i jenkinsci/blueocean:1.3.3

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,1 +1,1 @@
-docker run -d -v $("pwd")/volume-blueocean:/var/jenkins_home -p 8085:8080 -p 50000:50000 --name=jenkins-blueocean -i jenkinsci/blueocean:1.3.3
+docker run -d -v $("pwd")/volume-blueocean:/var/jenkins_home -p 80:8080 -p 50000:50000 --name=jenkins-blueocean -i jenkinsci/blueocean:1.3.3


### PR DESCRIPTION
### **What Happened**
- Docker container doesn't start with machine startup
- Accessing Jenkins web need to use port `8085`

### **Insight**
- I added `--restart=always` to let docker start this container after machine startup
- I changed binding jenkins port `(8080)` from `8085` to `80` so that we can access easily.
