### PR TITLE
Fix warning after update to 1.5.0

### DIFF
--- a/volume-blueocean/config.xml
+++ b/volume-blueocean/config.xml
@@ -41,6 +41,9 @@
     <string>JNLP2-connect</string>
   </disabledAgentProtocols>
   <label></label>
+  <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+    <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+  </crumbIssuer>
   <nodeProperties/>
   <globalNodeProperties/>
 </hudson>

--- a/volume-blueocean/config.xml
+++ b/volume-blueocean/config.xml
@@ -36,6 +36,10 @@
   </views>
   <primaryView>all</primaryView>
   <slaveAgentPort>50000</slaveAgentPort>
+  <disabledAgentProtocols>
+    <string>JNLP-connect</string>
+    <string>JNLP2-connect</string>
+  </disabledAgentProtocols>
   <label></label>
   <nodeProperties/>
   <globalNodeProperties/>


### PR DESCRIPTION
 ## What happened
- Warning message after update
 
## Insight
- I enabled CSRF to fix warning message [CSRF](https://support.cloudbees.com/hc/en-us/articles/219257077-CSRF-Protection-Explained)
- I enabled `JNLP4` only to fix deprecated message on `JNLP` [JNLP](https://github.com/widdix/aws-cf-templates/issues/144)

## Proof of work
### Before
![picture](https://i.imgur.com/ZlAGiWk.png)
### After
![picture](https://i.imgur.com/WiC5coN.png)